### PR TITLE
implemented dynamic import support

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,17 +21,22 @@ module.exports = {
 
     const vendorPath = 'vendor/flatpickr';
 
-    this.import(`${vendorPath}/flatpickr.js`);
+    const options = (app.options && app.options.flatpickr) || {};
 
-    if (app.options && app.options.flatpickr && app.options.flatpickr.theme) {
-      this.import(`${vendorPath}/themes/${app.options.flatpickr.theme}.css`);
+    // To be included in vendor file by default and should be ignored if includeInVendor is false
+    if (options.includeInVendor !== false) {
+      this.import(`${vendorPath}/flatpickr.js`);
+    }
+
+    if (options.theme) {
+      this.import(`${vendorPath}/themes/${options.theme}.css`);
     } else {
       this.import(`${vendorPath}/flatpickr.css`);
     }
 
     let locales = [];
-    if (app.options && app.options.flatpickr && app.options.flatpickr.locales) {
-      locales = app.options.flatpickr.locales;
+    if (options.locales) {
+      locales = options.locales;
       const localePaths = Array.isArray(locales)
         ? locales.map((locale) => `l10n/${locale}.js`)
         : [];


### PR DESCRIPTION
Flatpickr module is getting included in vendor file even though we are doing dynamic import. It should be ignored when we do an auto import of flatpickr.

This PR will help to exclude the flatpickr module in vendor file if client is using auto import functionality. 

Steps to do:

ember-cli-build.js

```
'use strict';

const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');

module.exports = function (defaults) {

  let app = new EmberAddon(defaults, options);

  /*
    This build file specifies the options for the dummy test app of this
    addon, located in `/tests/dummy`
    This build file does *not* influence how the addon or the app using it
    behave. You most likely want to be modifying `./index.js` or app's build file
  */

  flatpickr: {
    includeInVendor: false // true or false should decide whether it needs to be included in vendor file or not.
  }
};
```

```
import Route from '@ember/routing/route';

export default Route.extend({
  model() {
    return import('flatpickr').then((module) => module.default);
  }
});
```
